### PR TITLE
Descriptors Intermediate - Multiple properties, some with default values

### DIFF
--- a/docs/reference/descriptors/examples/Multiple_Properties_for_Person.py
+++ b/docs/reference/descriptors/examples/Multiple_Properties_for_Person.py
@@ -10,9 +10,9 @@ class Property(object):
     def __set__(self, inst, value):
         if inst is None:
             return self
-        else:
-            props = inst.__dict__.setdefault('_props', OrderedDict())
-            props[self._name] = value
+        
+        props = inst.__dict__.setdefault('_props', OrderedDict())
+        props[self._name] = value
 
     def __get__(self, inst, cls):
         if inst is None:
@@ -37,11 +37,15 @@ class Property(object):
         
         props[self._name] = self._default
 
+print Property
+
 ########
 
 class PropertyHasDefaultValue(object):
     def __init__(self, default):
         self._default = default
+
+print PropertyHasDefaultValue
 
 ########
 
@@ -50,6 +54,8 @@ class IntProperty(Property, PropertyHasDefaultValue):
         super(IntProperty, self).__init__(name, description)
         PropertyHasDefaultValue.__init__(self, default)
 
+print IntProperty
+
 ########
 
 
@@ -57,15 +63,39 @@ class StringProperty(Property):
     def __init__(self, name, description):
         super(StringProperty, self).__init__(name, description)
 
+print StringProperty
+
 ########
 
-class Person(object):
+class PropertiesBasedMixin():
+    def resetToDefaults(self):
+        print "\nResetting person's properties to default values\n"
+
+        instance_properties = self.__dict__['_props']
+
+        for prop_name in instance_properties:
+            prop = self.__class__.__dict__[prop_name]
+            print prop._name, instance_properties[prop_name]
+            try:
+                prop.resetValue(self)
+            except ValueError as e:
+                print "\t", e
+            else:
+                print "\t", prop._name, instance_properties[prop_name]
+
+print PropertiesBasedMixin
+
+########
+
+class Person(object, PropertiesBasedMixin):
     name = StringProperty("name", "Name of the person")
     age = IntProperty('age', "Age of the person", -1)
     degrees = IntProperty('degrees', "Number of degrees held by this person", 0)
     
     def __init__(self, name):
         self.name = name
+
+print Person
 
 ########
 
@@ -104,16 +134,6 @@ person2.degrees = 2
 
 print person2.__dict__
 
-print "\nResetting person's properties to default values\n"
+person2.resetToDefaults()
 
-instance_properties = person2.__dict__['_props']
-
-for prop_name in instance_properties:
-    prop = person2.__class__.__dict__[prop_name]
-    print prop._name, instance_properties[prop_name]
-    try:
-        prop.resetValue(person2)
-    except ValueError as e:
-        print "\t", e
-    else:
-        print "\t", prop._name, instance_properties[prop_name]
+print person2.__dict__


### PR DESCRIPTION
Introduced a Mixin

```python

>>> (executing line 1 of "Person.py")

>>> (executing lines 4 to 40 of "Person.py")
<class '__main__.Property'>

>>> (executing lines 43 to 48 of "Person.py")
<class '__main__.PropertyHasDefaultValue'>

>>> (executing lines 51 to 57 of "Person.py")
<class '__main__.IntProperty'>

>>> (executing lines 60 to 66 of "Person.py")
<class '__main__.StringProperty'>

>>> (executing lines 69 to 86 of "Person.py")
__main__.PropertiesBasedMixin

>>> (executing lines 89 to 98 of "Person.py")
<class '__main__.Person'>

>>> (executing lines 101 to 104 of "Person.py")
Name of the person
age
Age of the person

>>> (executing lines 107 to 115 of "Person.py")
{'_props': OrderedDict([('name', 'Bugs Bunny')])}
{'_props': OrderedDict([('name', 'Bugs Bunny'), ('age', 30), ('degrees', 10000L)])}

>>> (executing lines 118 to 139 of "Person.py")
{'_props': OrderedDict([('name', 'Daffy Duck')])}
Property cannot have a default value, so cannot reset to default
Daffy Duck
-1
0
{'_props': OrderedDict([('name', 'Daffy Duck'), ('age', 35), ('degrees', 2)])}

Resetting person's properties to default values

name Daffy Duck
	Property cannot have a default value, so cannot reset to default
age 35
	age -1
degrees 2
	degrees 0
{'_props': OrderedDict([('name', 'Daffy Duck'), ('age', -1), ('degrees', 0)])}

>>> 
```